### PR TITLE
Use flexbox instead of position absolute for admin

### DIFF
--- a/_includes/sass/layouts/_admin.scss
+++ b/_includes/sass/layouts/_admin.scss
@@ -1,16 +1,15 @@
 .admin {
-	@include cover;
-	&-nav,
-	&-content {
-		@include cover;
-		@include scroll;
-	}
-	&-nav {
-		right: auto;
-		width: 240px;
-	}
-	&-content {
-		left: 240px;
-		padding: 20px 20px 20px 30px;
-	}
+  @include cover;
+  @include flexbox;
+  &-nav,
+  &-content {
+    @include scroll;
+  }
+  &-nav {
+    @include flex(0, 0, 240px);
+  }
+  &-content {
+    @include flex(1, 1, auto);
+    padding: 20px 20px 20px 30px;
+  }
 }


### PR DESCRIPTION
Related to: [placeholder]

#### Why?

An element that is positioned absolute does not influence the height of the parent element. I'm rearranging some elements, and want elements with the `.admin` + related classes to influence the parent height. We can achieve the same layout with flexbox.

#### UI Goals:

* [x] The nav/content columns apply at all resolutions
* [x] Only the content column scrolls
* [x] The nav column is always 240px wide