### PR TITLE
Green + Red AA Compliant Foreground Colors

### DIFF
--- a/_includes/sass/base/_background.scss
+++ b/_includes/sass/base/_background.scss
@@ -1,0 +1,30 @@
+$colors: (
+	"red":$red,
+	"orange":$orange,
+	"yellow":$yellow,
+	"green":$green,
+	"blue":$blue,
+	"purple":$purple,
+	"navy":$navy,
+	"gray":$gray
+);
+
+@each $var, $color in $colors {
+  .bg-#{$var} { background-color: $color !important; }
+	.bg-#{$var}-dark { background-color: dark($color) !important; }
+	.bg-#{$var}-darker { background-color: darker($color) !important; }
+	.bg-#{$var}-darkest { background-color: darkest($color) !important; }
+	.bg-#{$var}-light { background-color: light($color) !important; }
+	.bg-#{$var}-lighter { background-color: lighter($color) !important; }
+	.bg-#{$var}-lightest { background-color: lightest($color) !important; }
+	.bg-#{$var}-highlight { background-color: highlight($color) !important; }
+  .bg-#{$var}-lowlight { background-color: lowlight($color) !important; }
+}
+
+.bg-silver { background-color: $silver; }
+.bg-silver-light { background-color: $silver-light !important; }
+.bg-silver-dark { background-color: $silver-dark !important; }
+.bg-silver-darker { background-color: $silver-darker !important; }
+.bg-silver-darkest { background-color: $silver-darkest !important; }
+
+.bg-transparent { background-color: transparent !important; }

--- a/_includes/sass/base/_base.scss
+++ b/_includes/sass/base/_base.scss
@@ -2,6 +2,7 @@
 @import "utilities";
 @import "print";
 @import "color";
+@import "background";
 @import "images";
 @import "type";
 @import "icons";

--- a/_includes/sass/base/_color.scss
+++ b/_includes/sass/base/_color.scss
@@ -9,6 +9,7 @@ $colors: (
 	"gray":$gray
 );
 
+
 @each $var, $color in $colors {
 	.text-#{$var} { color: $color !important; }
 	.text-#{$var}-dark { color: dark($color) !important; }
@@ -20,12 +21,19 @@ $colors: (
 	.text-#{$var}-highlight { color: highlight($color) !important; }
 	.text-#{$var}-lowlight { color: lowlight($color) !important; }
 }
-
-
-.text-success { color: dark($brand-success) !important; }
-.text-danger { color: dark($brand-danger) !important; }
-.text-warning { color: dark($brand-warning) !important; }
-.text-info { color: dark($brand-info) !important; }
+	
+// v1 customized the variant to use "dark" shade of our brand colors
+@if $version < 2 {
+	.text-success { color: dark($brand-success) !important; }
+	.text-danger { color: dark($brand-danger) !important; }
+	.text-warning { color: dark($brand-warning) !important; }
+	.text-info { color: dark($brand-info) !important; }
+} @else {
+	.text-success { color: $state-success-text !important; }
+	.text-danger { color: $state-info-text !important; }
+	.text-warning { color: $state-warning-text !important; }
+	.text-info { color: $state-danger-text !important; }
+}
 
 .text-white { color: white !important; }
 .text-light { color: $light !important; }

--- a/_includes/sass/base/_color.scss
+++ b/_includes/sass/base/_color.scss
@@ -19,16 +19,6 @@ $colors: (
 	.text-#{$var}-lightest { color: lightest($color) !important; }
 	.text-#{$var}-highlight { color: highlight($color) !important; }
 	.text-#{$var}-lowlight { color: lowlight($color) !important; }
-
-	.bg-#{$var} { background-color: $color !important; }
-	.bg-#{$var}-dark { background-color: dark($color) !important; }
-	.bg-#{$var}-darker { background-color: darker($color) !important; }
-	.bg-#{$var}-darkest { background-color: darkest($color) !important; }
-	.bg-#{$var}-light { background-color: light($color) !important; }
-	.bg-#{$var}-lighter { background-color: lighter($color) !important; }
-	.bg-#{$var}-lightest { background-color: lightest($color) !important; }
-	.bg-#{$var}-highlight { background-color: highlight($color) !important; }
-	.bg-#{$var}-lowlight { background-color: lowlight($color) !important; }
 }
 
 
@@ -53,14 +43,6 @@ $colors: (
 .text-silver-dark { color: $silver-dark !important; }
 .text-silver-darker { color: $silver-darker !important; }
 .text-silver-darkest { color: $silver-darkest !important; }
-
-.bg-silver { background-color: $silver; }
-.bg-silver-light { background-color: $silver-light !important; }
-.bg-silver-dark { background-color: $silver-dark !important; }
-.bg-silver-darker { background-color: $silver-darker !important; }
-.bg-silver-darkest { background-color: $silver-darkest !important; }
-
-.bg-transparent { background-color: transparent !important; }
 
 .faint { opacity: .5; }
 .fainter { opacity: .3; }

--- a/_includes/sass/sass.scss
+++ b/_includes/sass/sass.scss
@@ -24,12 +24,26 @@
 
 @import "sass/custom/custom";
 
-.brand-v2 {
+// Individually import brand-v2 overridden styles from:
+// - "sass/base/base"
+// - "sass/bootstrap/bootstrap"
+.brand-v2-text-color {
 	@import "sass/variables/colors-v2";
 	@import "sass/variables/variables";
 
-	// Individually import brand-v2 overridden styles from:
-	// - "sass/base/base"
-	// - "sass/bootstrap/bootstrap"
 	@import "sass/base/color";
+}
+
+.brand-v2-bg-color {
+	@import "sass/variables/colors-v2";
+	@import "sass/variables/variables";
+
+	@import "sass/base/background";
+}
+
+.brand-v2-label-color {
+	@import "sass/variables/colors-v2";
+	@import "sass/variables/variables";
+
+	@import "sass/bootstrap/labels";
 }

--- a/_includes/sass/sass.scss
+++ b/_includes/sass/sass.scss
@@ -27,21 +27,21 @@
 // Individually import brand-v2 overridden styles from:
 // - "sass/base/base"
 // - "sass/bootstrap/bootstrap"
-.brand-v2-text-color {
+.brand-v2-text-color:not(.ide-dark) {
 	@import "sass/variables/colors-v2";
 	@import "sass/variables/variables";
 
 	@import "sass/base/color";
 }
 
-.brand-v2-bg-color {
+.brand-v2-bg-color:not(.ide-dark) {
 	@import "sass/variables/colors-v2";
 	@import "sass/variables/variables";
 
 	@import "sass/base/background";
 }
 
-.brand-v2-label-color {
+.brand-v2-label-color:not(.ide-dark) {
 	@import "sass/variables/colors-v2";
 	@import "sass/variables/variables";
 

--- a/_includes/sass/sass.scss
+++ b/_includes/sass/sass.scss
@@ -1,5 +1,6 @@
 @charset "utf-8";
 @import "sass/maths/maths";
+@import "sass/variables/colors-v1";
 @import "sass/variables/variables";
 @import "sass/mixins/mixins";
 
@@ -22,3 +23,13 @@
 @import "sass/layouts/layouts";
 
 @import "sass/custom/custom";
+
+.brand-v2 {
+	@import "sass/variables/colors-v2";
+	@import "sass/variables/variables";
+
+	// Individually import brand-v2 overridden styles from:
+	// - "sass/base/base"
+	// - "sass/bootstrap/bootstrap"
+	@import "sass/base/color";
+}

--- a/_includes/sass/sass.scss
+++ b/_includes/sass/sass.scss
@@ -1,4 +1,7 @@
 @charset "utf-8";
+
+$version: 1;
+
 @import "sass/maths/maths";
 @import "sass/variables/colors-v1";
 @import "sass/variables/variables";
@@ -27,7 +30,11 @@
 // Individually import brand-v2 overridden styles from:
 // - "sass/base/base"
 // - "sass/bootstrap/bootstrap"
-.brand-v2-text-color:not(.ide-dark) {
+//
+// brand-v2 may change, and should not be considered a stable api
+$version: 2;
+
+.brand-v2-text-color:not(.ide-dark) {	
 	@import "sass/variables/colors-v2";
 	@import "sass/variables/variables";
 

--- a/_includes/sass/variables/_colors-v1.scss
+++ b/_includes/sass/variables/_colors-v1.scss
@@ -1,0 +1,13 @@
+//
+// Colors
+// --------------------------------------------------
+$red:                                            #ff694b;
+$orange:                                         $red;
+$yellow:                                         #ffcc00;
+$green:                                          #7ec631;
+$blue:                                           #00bbbb;
+$purple:                                         #7f6cc5;
+$navy:                                           #005e7a;
+$gray:                                           #8b969e;
+$silver:                                         #f0f2f4;
+$outline:                                        rgba(0,30,60,.03);

--- a/_includes/sass/variables/_colors-v2.scss
+++ b/_includes/sass/variables/_colors-v2.scss
@@ -2,12 +2,12 @@
 // Colors
 // --------------------------------------------------
 $red:                                            #e21b10;
-$orange:                                         #ff694b; // v1
+$orange:                                         #ff5722;
 $yellow:                                         #ffcc00; // v1
 $green:                                          #3a8717;
 $blue:                                           #00bbbb; // v1
 $purple:                                         #7f6cc5; // v1
 $navy:                                           #005e7a; // v1
-$gray:                                           #8b969e; // v1
+$gray:                                           #8b969e; // v1 & v2
 $silver:                                         #f0f2f4; // v1
 $outline:                                        rgba(0,30,60,.03);

--- a/_includes/sass/variables/_colors-v2.scss
+++ b/_includes/sass/variables/_colors-v2.scss
@@ -1,0 +1,13 @@
+//
+// Colors
+// --------------------------------------------------
+$red:                                            #e21b10;
+$orange:                                         #ff694b; // v1
+$yellow:                                         #ffcc00; // v1
+$green:                                          #3a8717;
+$blue:                                           #00bbbb; // v1
+$purple:                                         #7f6cc5; // v1
+$navy:                                           #005e7a; // v1
+$gray:                                           #8b969e; // v1
+$silver:                                         #f0f2f4; // v1
+$outline:                                        rgba(0,30,60,.03);

--- a/_includes/sass/variables/_variables.scss
+++ b/_includes/sass/variables/_variables.scss
@@ -1,18 +1,4 @@
 //
-// Colors
-// --------------------------------------------------
-$red:                                            #ff694b;
-$orange:                                         $red;
-$yellow:                                         #ffcc00;
-$green:                                          #7ec631;
-$blue:                                           #00bbbb;
-$purple:                                         #7f6cc5;
-$navy:                                           #005e7a;
-$gray:                                           #8b969e;
-$silver:                                         #f0f2f4;
-$outline:                                        rgba(0,30,60,.03);
-
-//
 // Neutrals
 // --------------------------------------------------
 $gray-light:                                     lighter($gray);


### PR DESCRIPTION
Adds opt-in accessible colors to our styles.

- `.brand-v2-text-color`: applies new color palette to classes like `text-[success, info, danger, etc.]`
- `.brand-v2-bg-color`: applies new color palette to classes like `bg-[blue, green, etc.]`
- `.brand-v2-label-color`: applies new color palette to classes like `label-[success, info, danger, etc.]`

To use classes that consume these colors, you have to be within the scope of `.brand-v2`. This context class is the proposed way to be able to add more opt-in classes that require minimal HTML changes.

These classes are also ignored by the Web IDE's dark mode. We can update this later if it's an undesired effect.

See [Sass Nesting](https://sass-lang.com/documentation/at-rules/import#nesting) for more details.