### PR TITLE
Corrected run history success label color variable

### DIFF
--- a/_includes/sass/bootstrap/_labels.scss
+++ b/_includes/sass/bootstrap/_labels.scss
@@ -25,7 +25,7 @@
 a.label {
 	&:hover, &:focus {
 		&.label-default { color: darkest($label-color); }
-		&.label-success { color: darkest($brand-success); }
+		&.label-success { color: $green; }
 		&.label-info { color: darkest($brand-info); }
 		&.label-warning { color: darkest($brand-warning); }
 		&.label-danger { color: darkest($brand-danger); }

--- a/_includes/sass/bootstrap/_labels.scss
+++ b/_includes/sass/bootstrap/_labels.scss
@@ -6,7 +6,7 @@
 	padding: 0;
 	border: 0;
 	&-default { color: $label-color; }
-	&-success { color: #{dark($brand-success)}; }
+	&-success { color: $green; }
 	&-info { color: #{dark($brand-info)}; }
 	&-warning { color: #{dark($brand-warning)}; }
 	&-danger { color: #{dark($brand-danger)}; }
@@ -25,7 +25,7 @@
 a.label {
 	&:hover, &:focus {
 		&.label-default { color: darkest($label-color); }
-		&.label-success { color: $green; }
+		&.label-success { color: darkest($brand-success); }
 		&.label-info { color: darkest($brand-info); }
 		&.label-warning { color: darkest($brand-warning); }
 		&.label-danger { color: darkest($brand-danger); }


### PR DESCRIPTION
Related ticket: https://github.com/fishtown-analytics/dbt-cloud/issues/1600

Success label for run history was displaying as #2c6912, corrected this to #3a8717.
<img width="1310" alt="Screen Shot 2020-08-18 at 1 45 53 PM" src="https://user-images.githubusercontent.com/61424614/90547229-2b1ed000-e159-11ea-98a4-552cb1002869.png">
