### PR TITLE
Add classes to tag styles and cleanup some fragmented rules

### DIFF
--- a/_includes/sass/base/_base.scss
+++ b/_includes/sass/base/_base.scss
@@ -8,3 +8,4 @@
 @import "icons";
 @import "glyphs";
 @import "options";
+@import "tailwind-compat";

--- a/_includes/sass/base/_images.scss
+++ b/_includes/sass/base/_images.scss
@@ -1,4 +1,4 @@
-img {
+img, .img {
 	display: block;
 	max-width: 100%;
 }

--- a/_includes/sass/base/_tailwind-compat.scss
+++ b/_includes/sass/base/_tailwind-compat.scss
@@ -1,0 +1,12 @@
+  // This file should only override styles applied by Fishtown UI/Tailwind
+
+// Tailwind messes with border styles, which affected table headers
+// https://tailwindcss.com/docs/preflight#border-styles-are-reset-globally
+.table * {
+	border-style: none;
+}
+
+// Tailwind strips lists by defaul
+.ul {
+  list-style-type: disc;
+}

--- a/_includes/sass/base/_type.scss
+++ b/_includes/sass/base/_type.scss
@@ -1,4 +1,4 @@
-body {
+body, .dbt-cloud-body {
 	@include font-size-base;
 	font-family: $font-family-base;
 	background: $body-bg;
@@ -28,19 +28,19 @@ mark { background: $state-info-bg; color: $dark; padding: .1em 0; @include radiu
 
 iframe { margin: 0; display: block; }
 label { margin: .5em 0; font-weight: normal; }
-hr { margin: 3em 0; border-top: 1px solid $hr-border;
+hr, .hr { margin: 3em 0; border-top: 1px solid $hr-border;
 	&.short { margin: 1.5em 0; }
 }
-blockquote, ul, ol, p, .field, .table { margin: 1.5em 0; }
-#{h()} { margin: 1.5em 0 .5em; }
-ul, ol { padding-left: 1.25em; }
+p, .field, .table { margin: 1.5em 0; }
+#{h()}, .text-base, .text-large, .text-larger, .text-largest { margin: 1.5em 0 .5em; }
+ul, ol, .ul, .ol { margin: 1.5em 0; padding-left: 1.25em; }
 dl { dt + dd { margin-bottom: 1em; } }
-blockquote { padding: 0; font-size: inherit; }
+blockquote {  margin: 1.5em 0; padding: 0; font-size: inherit; }
 
 // SIZES -------------------------------------------------------
 
 small, .small, .text-small { @include font-size-small; }
-#{h()} { font-weight: bold; letter-spacing: .01em; }
+#{h()}, .text-base, .text-large, .text-larger, .text-largest { font-weight: bold; letter-spacing: .01em; }
 #{h(5,6)}, .text-base { @include font-size-base; }
 #{h(4)}, .text-large { @include font-size-large; }
 #{h(3)}, .text-larger { @include font-size-larger; }


### PR DESCRIPTION
Adds classes needed for https://github.com/fishtown-analytics/dbt-cloud/issues/2881.
- Add `.img`, `.dbt-cloud-body`, `.hr`, `.ul`, `.ol`
- Did not add `.blockquote` or classes for elements where there are none in dbt Cloud
- Consolidated margin rules
- Override some incompatible Tailwind preflight rules