### PR TITLE
Fix table style that breaks children's borders

### DIFF
--- a/_includes/sass/base/_tailwind-compat.scss
+++ b/_includes/sass/base/_tailwind-compat.scss
@@ -2,7 +2,7 @@
 
 // Tailwind messes with border styles, which affected table headers
 // https://tailwindcss.com/docs/preflight#border-styles-are-reset-globally
-.table * {
+.table th {
 	border-style: none;
 }
 


### PR DESCRIPTION
Addresses https://github.com/fishtown-analytics/dbt-cloud/issues/3155

Reported in https://fishtownanalytics.slack.com/archives/C0164QWG2NA/p1623190772063900?thread_ts=1622817853.056600&cid=C0164QWG2NA

What the fix looks like:
<img width="208" alt="Screen Shot 2021-06-09 at 8 28 51 PM" src="https://user-images.githubusercontent.com/4501220/121455756-03605900-c973-11eb-8f2d-dd2b25b3e004.png">

I also verified that the Jobs tables still appears as expected, which is why we made this change in the first place.