### PR TITLE
Fix border styles for checkbox components embedded in tables

### DIFF
--- a/_includes/sass/base/_glyphs.scss
+++ b/_includes/sass/base/_glyphs.scss
@@ -86,6 +86,7 @@ $glyph-size: 24px;
 	&-check, &-radio {
 		font-size: 16px;
 		use { opacity: 0; }
+		border-style: solid;
 		border: 2px solid currentColor;
 		opacity: .25;
 		:hover > &, :focus ~ & { opacity: .5; }


### PR DESCRIPTION
We've had a few reports of empty checkboxes disappearing from the UI when attempting to edit them in notification settings. Some investigation showed that this was happening only to checkboxes that were embedded in `<table>` elements, and was caused by the following global table style cascading down to the checkbox svg elements:

```
.table * {
    border-style: none;
}
```

The more permanent fix here likely involves moving away from a table layout and / or migrating to react + fui, but for now I've added a `border-style: solid` property to all legacy checkbox components since that seems like a safer default.

Before:
![Screen Shot 2021-07-12 at 2 36 00 PM](https://user-images.githubusercontent.com/3207842/125338679-7cf6b880-e31e-11eb-9660-7e7944295f96.png)


After:
![Screen Shot 2021-07-12 at 2 17 23 PM](https://user-images.githubusercontent.com/3207842/125338685-7ec07c00-e31e-11eb-941b-0accc9723608.png)

BONUS FIX:

Looks like this also fixes a bug with radio buttons:

Before:
![Screen Shot 2021-07-12 at 3 27 47 PM](https://user-images.githubusercontent.com/3207842/125345024-0067d800-e326-11eb-86f2-024fe8cab29a.png)


After:
![Screen Shot 2021-07-12 at 3 27 45 PM](https://user-images.githubusercontent.com/3207842/125345034-0362c880-e326-11eb-88a0-de58cd4d42a4.png)

