### PR TITLE
update used gh actions ahead of node12 deprecation

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,9 +13,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Use Node.js
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: "12.x"
       - run: npm install


### PR DESCRIPTION
Please merge this update today! [node 12 support dropping tomorrow](https://github.blog/changelog/2023-05-04-github-actions-all-actions-will-run-on-node16-instead-of-node12/) and these version updates to Github Actions get ahead of that. Resolves RELENG-144